### PR TITLE
Rounding balances

### DIFF
--- a/ExpensesSplitter.WebApi.Tests/Algorithms/SettlementSolverTests.cs
+++ b/ExpensesSplitter.WebApi.Tests/Algorithms/SettlementSolverTests.cs
@@ -115,6 +115,24 @@ namespace ExpensesSplitter.WebApi.Tests.Algorithms
             Assert.Contains(result, t => IsTransaction(t, "C", "E", 3));
             Assert.Contains(result, t => IsTransaction(t, "D", "E", 4));
         }
+        
+        [Fact]
+        public void Solve_WhenSumOfBalancesIsNotZero()
+        {
+            var balances = new[]
+            {
+                CreateUserBalance("A", 6.67M),
+                CreateUserBalance("B", -3.33M),
+                CreateUserBalance("C", -3.33M),
+            };
+            var solver = new SettlementSolver(balances);
+
+            var result = solver.Solve();
+            
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, t => IsTransaction(t, "B", "A", 3.33M));
+            Assert.Contains(result, t => IsTransaction(t, "C", "A", 3.33M));
+        }
 
         bool IsTransaction(SolutionTransaction t, string from, string to, decimal amount)
         {

--- a/ExpensesSplitter.WebApi.Tests/ExpensesSplitter.WebApi.Tests.csproj
+++ b/ExpensesSplitter.WebApi.Tests/ExpensesSplitter.WebApi.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ExpensesSplitter.WebApi.Tests/Providers/BalancesProviderTests.cs
+++ b/ExpensesSplitter.WebApi.Tests/Providers/BalancesProviderTests.cs
@@ -1,0 +1,87 @@
+using System;
+using ExpensesSplitter.WebApi.Models;
+using ExpensesSplitter.WebApi.Providers;
+using ExpensesSplitter.WebApi.Repositories;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace ExpensesSplitter.WebApi.Tests.Providers
+{
+    public class BalancesProviderTests
+    {
+        private readonly IExpensesRepository _expensesRepository = Substitute.For<IExpensesRepository>();
+        private readonly ISettlementUsersRepository _settlementUsersRepository = Substitute.For<ISettlementUsersRepository>();
+        private readonly ILogger<BalancesProvider> _logger = Substitute.For<ILogger<BalancesProvider>>();
+        private readonly string _settlementId = "123";
+        
+        [Fact]
+        public void GetBalances_SplitsExpenses()
+        {
+            var userA = CreateSettlementUser();
+            var userB = CreateSettlementUser();
+            var userC = CreateSettlementUser();
+            var users = new[] {userA, userB, userC};
+            _settlementUsersRepository.GetSettlementUsers(_settlementId)
+                .Returns(users);
+            var expenses = new[]
+            {
+                new Expense {WhoPaid = userA, Amount = 9}
+            };
+            _expensesRepository.GetExpenses(_settlementId)
+                .Returns(expenses);
+            var provider = CreateBalancesProvider();
+
+            var balances = provider.GetBalances(_settlementId);
+            
+            Assert.Collection(balances,
+                item => Assert.Equal(6M, item.Balance),
+                item => Assert.Equal(-3M, item.Balance),
+                item => Assert.Equal(-3M, item.Balance)
+            );
+        }
+        
+        [Fact]
+        public void GetBalances_RoundsBalances()
+        {
+            var userA = CreateSettlementUser();
+            var userB = CreateSettlementUser();
+            var userC = CreateSettlementUser();
+            var users = new[] {userA, userB, userC};
+            _settlementUsersRepository.GetSettlementUsers(_settlementId)
+                .Returns(users);
+            var expenses = new[]
+            {
+                new Expense {WhoPaid = userA, Amount = 10}
+            };
+            _expensesRepository.GetExpenses(_settlementId)
+                .Returns(expenses);
+            var provider = CreateBalancesProvider();
+
+            var balances = provider.GetBalances(_settlementId);
+            
+            Assert.Collection(balances,
+                item => Assert.Equal(6.67M, item.Balance),
+                item => Assert.Equal(-3.33M, item.Balance),
+                item => Assert.Equal(-3.33M, item.Balance)
+            );
+        }
+
+        BalancesProvider CreateBalancesProvider()
+        {
+            return new BalancesProvider(
+                _expensesRepository,
+                _settlementUsersRepository,
+                _logger
+            );
+        }
+
+        SettlementUser CreateSettlementUser()
+        {
+            return new SettlementUser
+            {
+                Id = Guid.NewGuid()
+            };
+        }
+    }
+}

--- a/ExpensesSplitter.WebApi/Providers/BalancesProvider.cs
+++ b/ExpensesSplitter.WebApi/Providers/BalancesProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ExpensesSplitter.WebApi.Models;
@@ -37,6 +38,7 @@ namespace ExpensesSplitter.WebApi.Providers
                 .ToList();
             var usersCount = settlementUsers.Count();
             var commonExpense = total / usersCount;
+            commonExpense = Math.Floor(commonExpense * 100) / 100;
             return settlementUsers
                 .Select(u => new UserBalance
                 {


### PR DESCRIPTION
Dodałem zaokrąglanie w dół kwot w bilansie. `Solver` będzie nadal dobrze działał, jedynie suma bilansu niekoniecznie musi być równa 0 (ale nie powinno to w niczym przeszkadzać).